### PR TITLE
Feature/kafka producer service

### DIFF
--- a/kafka-microservices/kafka-producer-wikimedia/pom.xml
+++ b/kafka-microservices/kafka-producer-wikimedia/pom.xml
@@ -13,6 +13,33 @@
     <groupId>com.kafka-tutorial</groupId>
     <artifactId>kafka-producer-wikimedia</artifactId>
 
+    <dependencies>
+        <!-- https://mvnrepository.com/artifact/com.launchdarkly/okhttp-eventsource -->
+        <dependency>
+            <groupId>com.launchdarkly</groupId>
+            <artifactId>okhttp-eventsource</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.11.0</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.15.2</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.15.2</version>
+        </dependency>
+    </dependencies>
+
     <properties>
         <maven.compiler.source>18</maven.compiler.source>
         <maven.compiler.target>18</maven.compiler.target>

--- a/kafka-microservices/kafka-producer-wikimedia/src/main/java/com/learningkafka/springboot/config/KafkaProducerInitializer.java
+++ b/kafka-microservices/kafka-producer-wikimedia/src/main/java/com/learningkafka/springboot/config/KafkaProducerInitializer.java
@@ -1,0 +1,18 @@
+package com.learningkafka.springboot.config;
+
+import com.learningkafka.springboot.producer.WikimediaChangesProducer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class KafkaProducerInitializer implements CommandLineRunner {
+
+    private final WikimediaChangesProducer wikimediaChangesProducer;
+
+    @Override
+    public void run(String... args) throws Exception {
+        wikimediaChangesProducer.sendMessage();
+    }
+}

--- a/kafka-microservices/kafka-producer-wikimedia/src/main/java/com/learningkafka/springboot/config/KafkaTopicConfig.java
+++ b/kafka-microservices/kafka-producer-wikimedia/src/main/java/com/learningkafka/springboot/config/KafkaTopicConfig.java
@@ -1,5 +1,6 @@
 package com.learningkafka.springboot.config;
 
+import com.learningkafka.springboot.constants.KafkaConstants;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,7 +12,7 @@ public class KafkaTopicConfig {
     @Bean
     public NewTopic topic() {
         return TopicBuilder
-                .name("wikimedia_recent_changes")
+                .name(KafkaConstants.TOPIC_NAME)
                 .build();
     }
 }

--- a/kafka-microservices/kafka-producer-wikimedia/src/main/java/com/learningkafka/springboot/constants/KafkaConstants.java
+++ b/kafka-microservices/kafka-producer-wikimedia/src/main/java/com/learningkafka/springboot/constants/KafkaConstants.java
@@ -1,0 +1,7 @@
+package com.learningkafka.springboot.constants;
+
+public class KafkaConstants {
+
+    public static final String TOPIC_NAME = "wikimedia_recent_changes";
+    public static final String STREAM_DATA_URL = "https://stream.wikimedia.org/v2/stream/recentchange";
+}

--- a/kafka-microservices/kafka-producer-wikimedia/src/main/java/com/learningkafka/springboot/handler/WikimediaChangesHandler.java
+++ b/kafka-microservices/kafka-producer-wikimedia/src/main/java/com/learningkafka/springboot/handler/WikimediaChangesHandler.java
@@ -1,0 +1,44 @@
+package com.learningkafka.springboot.handler;
+
+import com.launchdarkly.eventsource.EventHandler;
+import com.launchdarkly.eventsource.MessageEvent;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@RequiredArgsConstructor
+public class WikimediaChangesHandler implements EventHandler {
+
+    private final Logger LOGGER = LoggerFactory.getLogger(WikimediaChangesHandler.class);
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final String topic;
+
+    @Override
+    public void onOpen() throws Exception {
+
+    }
+
+    @Override
+    public void onClosed() throws Exception {
+
+    }
+
+    @Override
+    public void onMessage(String event, MessageEvent messageEvent) throws Exception {
+        LOGGER.info(String.format("Event data -> %s", messageEvent.getData()));
+
+        kafkaTemplate.send(topic, messageEvent.getData());
+    }
+
+    @Override
+    public void onComment(String comment) throws Exception {
+
+    }
+
+    @Override
+    public void onError(Throwable t) {
+
+    }
+}

--- a/kafka-microservices/kafka-producer-wikimedia/src/main/java/com/learningkafka/springboot/producer/WikimediaChangesProducer.java
+++ b/kafka-microservices/kafka-producer-wikimedia/src/main/java/com/learningkafka/springboot/producer/WikimediaChangesProducer.java
@@ -1,0 +1,35 @@
+package com.learningkafka.springboot.producer;
+
+import com.launchdarkly.eventsource.EventHandler;
+import com.launchdarkly.eventsource.EventSource;
+import com.learningkafka.springboot.constants.KafkaConstants;
+import com.learningkafka.springboot.handler.WikimediaChangesHandler;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class WikimediaChangesProducer {
+
+    private final Logger LOGGER = LoggerFactory.getLogger(WikimediaChangesProducer.class);
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public void sendMessage() throws InterruptedException {
+        //to read real time stream data from wikimedia, we use event source
+        EventHandler eventHandler = new WikimediaChangesHandler(kafkaTemplate, KafkaConstants.TOPIC_NAME);
+        EventSource.Builder eventSourceBuilder = new EventSource
+                .Builder(eventHandler, URI.create(KafkaConstants.STREAM_DATA_URL));
+        EventSource eventSource = eventSourceBuilder.build();
+
+        eventSource.start();
+
+        TimeUnit.MINUTES.sleep(10);
+    }
+}

--- a/kafka-microservices/kafka-producer-wikimedia/src/main/resources/application.properties
+++ b/kafka-microservices/kafka-producer-wikimedia/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+spring.output.ansi.enabled=always
+
 spring.kafka.producer.bootstrap-servers=localhost:9092
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer


### PR DESCRIPTION
Added okhttp dependencies to implement EventSource to read the data form https://stream.wikimedia.org/v2/stream/recentchange.
KafkaProducerInitializer class to init the producer service (WikimediaChangesProducer class).

All strings moved to an universal constants class (KafkaConstants class).

EventHandler implemented to override the onMessage method to receive the data and send it to the corresponding topic (wikimedia_recent_changes).

Colours added to console when running the application.